### PR TITLE
Add an option to keep the data file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Alternatively, you can specify the options you want. Here's an example showing t
 
     activate :navtree do |options|
       options.data_file = 'tree.yml' # The data file where our navtree is stored.
-      options.data_file_keep = false # The file with directory tree will not be overwritten.
+      options.automatic_tree_updates = true # The tree.yml file will be updated automatically when source files are changed.
       options.source_dir = 'source' # The `source` directory we want to represent in our nav tree.
       options.ignore_files = ['sitemap.xml', 'robots.txt'] # An array of files we want to ignore when building our tree.
       options.ignore_dir = ['assets'] # An array of directories we want to ignore when building our tree.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Alternatively, you can specify the options you want. Here's an example showing t
 
     activate :navtree do |options|
       options.data_file = 'tree.yml' # The data file where our navtree is stored.
+      options.data_file_keep = false # The file with directory tree will not be overwritten.
       options.source_dir = 'source' # The `source` directory we want to represent in our nav tree.
       options.ignore_files = ['sitemap.xml', 'robots.txt'] # An array of files we want to ignore when building our tree.
       options.ignore_dir = ['assets'] # An array of directories we want to ignore when building our tree.

--- a/lib/middleman-navtree/extension.rb
+++ b/lib/middleman-navtree/extension.rb
@@ -10,6 +10,7 @@ module Middleman
       # All the options for this extension
       option :source_dir, 'source', 'The directory our tree will begin at.'
       option :data_file, 'tree.yml', 'The file we will write our directory tree to.'
+      option :data_file_keep, false, 'The file with directory tree will not be overwritten.'
       option :ignore_files, ['sitemap.xml', 'robots.txt'], 'A list of filenames we want to ignore when building our tree.'
       option :ignore_dir, ['assets'], 'A list of directory names we want to ignore when building our tree.'
       option :home_title, 'Home', 'The default link title of the home page (located at "/"), if otherwise not detected.'
@@ -51,8 +52,10 @@ module Middleman
         # Write our directory tree to file as YAML.
         # @todo: This step doesn't rebuild during live-reload, which causes errors if you move files
         #        around during development. It may not be that hard to set up. Low priority though.
-        data_path = app.settings.data_dir + '/' + options.data_file
-        IO.write(data_path, YAML::dump(tree_hash))
+        unless options.data_file_keep
+          data_path = app.settings.data_dir + '/' + options.data_file
+          IO.write(data_path, YAML::dump(tree_hash))
+        end
       end
 
 

--- a/lib/middleman-navtree/extension.rb
+++ b/lib/middleman-navtree/extension.rb
@@ -10,7 +10,7 @@ module Middleman
       # All the options for this extension
       option :source_dir, 'source', 'The directory our tree will begin at.'
       option :data_file, 'tree.yml', 'The file we will write our directory tree to.'
-      option :data_file_keep, false, 'The file with directory tree will not be overwritten.'
+      option :automatic_tree_updates, true, 'The tree.yml file will be updated automatically when source files are changed.'
       option :ignore_files, ['sitemap.xml', 'robots.txt'], 'A list of filenames we want to ignore when building our tree.'
       option :ignore_dir, ['assets'], 'A list of directory names we want to ignore when building our tree.'
       option :home_title, 'Home', 'The default link title of the home page (located at "/"), if otherwise not detected.'
@@ -52,7 +52,7 @@ module Middleman
         # Write our directory tree to file as YAML.
         # @todo: This step doesn't rebuild during live-reload, which causes errors if you move files
         #        around during development. It may not be that hard to set up. Low priority though.
-        unless options.data_file_keep
+        if options.automatic_tree_updates
           data_path = app.settings.data_dir + '/' + options.data_file
           IO.write(data_path, YAML::dump(tree_hash))
         end


### PR DESCRIPTION
This PR addresses the problem reported in issue #1. I have tried a number of ways to achieve a sane Table of Contents for our documentation. This solution seemed to be the most elegant out of these options:

**Directory indexes**

I have tried to follow a convention of having ```index.md``` in each directory and using its page title. This worked pretty well, since I was able to define directory titles easily as any other page. However, it forced me to create unnecessary index files. Also, I was ordering the files and directories with number prefixes, which screws up the URLs.

**Overriding directory titles**

Then, I have patched the extension to override directory titles with an option, as was suggested in the issue. This also worked well, apart from the fact that I would have to maintain the titles in the ```config.rb```, which did not feel right. Additionally, it had the same problem of ordering items in the tree and ugly URLs.

**Manual tree file (this PR)**

Finally, I have decided the most usable way is to keep the data file with the tree and let maintain it manually. This allowed me to choose the directory titles, have a custom order, and keep nice URLs. It also serves as a good internal doc.