### PR TITLE
Make sure data dir exists before writing the tree file

### DIFF
--- a/lib/middleman-navtree/extension.rb
+++ b/lib/middleman-navtree/extension.rb
@@ -53,6 +53,8 @@ module Middleman
         # @todo: This step doesn't rebuild during live-reload, which causes errors if you move files
         #        around during development. It may not be that hard to set up. Low priority though.
         if options.automatic_tree_updates
+          FileUtils.mkdir_p(app.settings.data_dir)
+
           data_path = app.settings.data_dir + '/' + options.data_file
           IO.write(data_path, YAML::dump(tree_hash))
         end


### PR DESCRIPTION
A fresh Middleman installation doesn't have a `data` folder yet. This PR makes sure the folder exists before writing the `tree.yml` file.