### PR TITLE
adds directory index support

### DIFF
--- a/lib/middleman-navtree/extension.rb
+++ b/lib/middleman-navtree/extension.rb
@@ -14,9 +14,9 @@ module Middleman
       option :ignore_files, ['sitemap.xml', 'robots.txt'], 'A list of filenames we want to ignore when building our tree.'
       option :ignore_dir, ['assets'], 'A list of directory names we want to ignore when building our tree.'
       option :home_title, 'Home', 'The default link title of the home page (located at "/"), if otherwise not detected.'
-      option :promote_files, [], 'A list of files you want to push to the front of the tree (if they exist).'
+      option :promote_files, ['index.html.erb'], 'A list of files you want to push to the front of the tree (if they exist).'
       option :ext_whitelist, [], 'A whitelist of filename extensions (post-render) that we are allowing in our navtree. Example: [".html"]'
-      option :directory_index, true, "Enables directory indexing, where directories with index files will be rendered as links"
+      option :directory_index, false, "Enables directory indexing, where directories with index files will be rendered as links"
 
       # Helpers for use within templates and layouts.
       self.defined_helpers = [ ::Middleman::NavTree::Helpers ]

--- a/lib/middleman-navtree/extension.rb
+++ b/lib/middleman-navtree/extension.rb
@@ -14,8 +14,9 @@ module Middleman
       option :ignore_files, ['sitemap.xml', 'robots.txt'], 'A list of filenames we want to ignore when building our tree.'
       option :ignore_dir, ['assets'], 'A list of directory names we want to ignore when building our tree.'
       option :home_title, 'Home', 'The default link title of the home page (located at "/"), if otherwise not detected.'
-      option :promote_files, ['index.html.erb'], 'A list of files you want to push to the front of the tree (if they exist).'
+      option :promote_files, [], 'A list of files you want to push to the front of the tree (if they exist).'
       option :ext_whitelist, [], 'A whitelist of filename extensions (post-render) that we are allowing in our navtree. Example: [".html"]'
+      option :directory_index, true, "Enables directory indexing, where directories with index files will be rendered as links"
 
       # Helpers for use within templates and layouts.
       self.defined_helpers = [ ::Middleman::NavTree::Helpers ]

--- a/lib/middleman-navtree/helpers.rb
+++ b/lib/middleman-navtree/helpers.rb
@@ -145,8 +145,8 @@ module Middleman
         link = link_to(title, resource)
         "<li class='child #{resource_status(resource)}'>#{link}</li>"
       end
-      
-      # returns a resource from a provided value 
+
+      # returns a resource from a provided value
       def resource_from_value(value)
         extensionlessPath = sitemap.extensionless_path(value)
         unless extensionlessPath.end_with? ".html"
@@ -154,30 +154,31 @@ module Middleman
         end
         sitemap.find_resource_by_path(extensionlessPath)
       end
-      
+
       # if directory_index is enabled and the provided directory contains an index,
       # generate a linked li.parent
       # otherwise returns a normal (non-linked) HTML li.parent
       def directory_index_aware_li(key,value)
         name = format_directory_name(key)
         if extensions[:navtree].options[:directory_index] && index_file = value.keys.detect{|k| k.start_with?("index")}
-          # removes index.html from some/directory/index.html 
-          destination = value[index_file].split("/")[0..-2].join("/") + "/"
-          link = link_to(name, destination)
-          resource = sitemap.find_resource_by_path(destination)
+          # removes index.html from some/directory/index.html
+          destination = value[index_file].split("/")[0..-2].join("/") + "/index"
+          resource = sitemap.find_resource_by_page_id(destination.sub(/\A\//, ""))
+
+          link = link_to(name, resource.url)
           "<li class='parent #{resource_status(resource)}'><span class='parent-label'>#{link}</span>"
         else
-          "<li class='parent'><span class='parent-label'>#{name}</span>"
+          "<li class='parent xx'><span class='parent-label'>#{name}</span>"
         end
       end
-      
-      
+
+
       # checks if this resource is the current page
       # returns active if it is, an empty string otherwise
       def resource_status(resource)
-        resource == current_page ? 'active' : ''
+        resource == current_page ? 'active' : 'inactive'
       end
-      
+
     end
   end
 end

--- a/lib/middleman-navtree/helpers.rb
+++ b/lib/middleman-navtree/helpers.rb
@@ -10,7 +10,9 @@ module Middleman
           # This is a file.
           # Get the Sitemap resource for this file.
           # note: sitemap.extensionless_path converts the path to its 'post-build' extension.
+
           this_resource = resource_from_value(value)
+          return "" if this_resource.nil?
           unless extensions[:navtree].options[:directory_index] && this_resource.directory_index?
             html << child_li(this_resource) if this_resource
           end
@@ -160,11 +162,14 @@ module Middleman
       # otherwise returns a normal (non-linked) HTML li.parent
       def directory_index_aware_li(key,value)
         name = format_directory_name(key)
+
         if extensions[:navtree].options[:directory_index] && index_file = value.keys.detect{|k| k.start_with?("index")}
           # removes index.html from some/directory/index.html
-          destination = value[index_file].split("/")[0..-2].join("/") + "/index"
-          resource = sitemap.find_resource_by_page_id(destination.sub(/\A\//, ""))
-          link = link_to(name, resource.url)
+          destination = value[index_file].split("/")[0..-2].join("/") + "/"
+          link = link_to(name, destination)
+          resource_path = destination.sub(/\A\//, "").sub(".md.erb", "").gsub("%20", " ")
+          resource_path += "index" if resource_path.ends_with?("/")
+          resource = sitemap.find_resource_by_page_id(resource_path)
           "<li class='parent #{resource_status(resource)}'><span class='parent-label'>#{link}</span>"
         else
           "<li class='parent'><span class='parent-label'>#{name}</span>"
@@ -175,7 +180,7 @@ module Middleman
       # checks if this resource is the current page
       # returns active if it is, an empty string otherwise
       def resource_status(resource)
-        resource == current_page ? 'active' : 'inactive'
+        resource == current_page ? 'active' : ''
       end
 
     end

--- a/lib/middleman-navtree/helpers.rb
+++ b/lib/middleman-navtree/helpers.rb
@@ -10,12 +10,10 @@ module Middleman
           # This is a file.
           # Get the Sitemap resource for this file.
           # note: sitemap.extensionless_path converts the path to its 'post-build' extension.
-
           this_resource = resource_from_value(value)
           unless extensions[:navtree].options[:directory_index] && this_resource.directory_index?
             html << child_li(this_resource) if this_resource
           end
-
         else
           # This is the first level source directory. We treat it special because
           # it has no key and needs no list item.
@@ -141,13 +139,14 @@ module Middleman
 
       private
 
+      # generates an HTML li child from a given resource
       def child_li(resource)
-        active = resource == current_page ? 'active' : ''
         title = discover_title(resource)
         link = link_to(title, resource)
-        "<li class='child #{active}'>#{link}</li>"
+        "<li class='child #{resource_status(resource)}'>#{link}</li>"
       end
-
+      
+      # returns a resource from a provided value 
       def resource_from_value(value)
         extensionlessPath = sitemap.extensionless_path(value)
         unless extensionlessPath.end_with? ".html"
@@ -155,20 +154,30 @@ module Middleman
         end
         sitemap.find_resource_by_path(extensionlessPath)
       end
-
+      
+      # if directory_index is enabled and the provided directory contains an index,
+      # generate a linked li.parent
+      # otherwise returns a normal (non-linked) HTML li.parent
       def directory_index_aware_li(key,value)
         name = format_directory_name(key)
         if extensions[:navtree].options[:directory_index] && index_file = value.keys.detect{|k| k.start_with?("index")}
+          # removes index.html from some/directory/index.html 
           destination = value[index_file].split("/")[0..-2].join("/") + "/"
           link = link_to(name, destination)
           resource = sitemap.find_resource_by_path(destination)
-          active = resource == current_page ? 'active' : ''
-          "<li class='parent #{active}'><span class='parent-label'>#{link}</span>"
+          "<li class='parent #{resource_status(resource)}'><span class='parent-label'>#{link}</span>"
         else
           "<li class='parent'><span class='parent-label'>#{name}</span>"
         end
       end
-
+      
+      
+      # checks if this resource is the current page
+      # returns active if it is, an empty string otherwise
+      def resource_status(resource)
+        resource == current_page ? 'active' : ''
+      end
+      
     end
   end
 end

--- a/lib/middleman-navtree/helpers.rb
+++ b/lib/middleman-navtree/helpers.rb
@@ -164,11 +164,10 @@ module Middleman
           # removes index.html from some/directory/index.html
           destination = value[index_file].split("/")[0..-2].join("/") + "/index"
           resource = sitemap.find_resource_by_page_id(destination.sub(/\A\//, ""))
-
           link = link_to(name, resource.url)
           "<li class='parent #{resource_status(resource)}'><span class='parent-label'>#{link}</span>"
         else
-          "<li class='parent xx'><span class='parent-label'>#{name}</span>"
+          "<li class='parent'><span class='parent-label'>#{name}</span>"
         end
       end
 


### PR DESCRIPTION
Hello there, 

I stumbled upon your gem the other night and noticed it didn't do directory indexes the way I would expect. So, I did some hacking and think i have the desired behavior. This should address issue #12 

This is the structure i have:
![structure](https://cloud.githubusercontent.com/assets/931048/21279734/ccd606c8-c3af-11e6-81db-da1e6fb3fc27.png)

so `devices/` and `computers/` have `index` files, but not `projectors/`

with directory_index disabled (existing behavior):
![disabled](https://cloud.githubusercontent.com/assets/931048/21279765/fbd85782-c3af-11e6-8396-182e7a5a7a29.png)


With directory_index enabled (new behavior)
![enabled](https://cloud.githubusercontent.com/assets/931048/21279794/20f650b4-c3b0-11e6-9c07-3723c1039a7b.png)

I did some QA on my end and it seems to behave correctly. But please do give it look over and let me know!